### PR TITLE
[tests] Use almostEquals instead of equals in viewport test

### DIFF
--- a/client/src/features/viewport/viewport.spec.ts
+++ b/client/src/features/viewport/viewport.spec.ts
@@ -37,7 +37,7 @@ describe('ViewportCommand', () => {
 
     it('undo() works as expected', () => {
         cmd.undo(viewport, context)
-        expect(viewport.zoom).equals(viewportData.zoom)
+        expect(almostEquals(viewport.zoom, viewportData.zoom)).to.be.true
         expect(viewport.scroll).deep.equals(viewportData.scroll)
     })
 


### PR DESCRIPTION
I had this error when trying to run the tests for the first time :

```
47 passing (64ms)
  1 failing

  1) ViewportCommand undo() works as expected:

      AssertionError: expected 1.0000000000000002 to equal 1
      + expected - actual

      -1.0000000000000002
      +1
      at Context.<anonymous> (src/features/viewport/viewport.spec.ts:40:31)
```

I noticed that the other tests used almostEquals instead of equals so I changed it.