### PR TITLE
updated exaple1.multicore

### DIFF
--- a/client/examples/example01.multicore
+++ b/client/examples/example01.multicore
@@ -40,23 +40,18 @@ step 2 {
 }
 
 step 3 {
-    core 1 finished t0 { $pc = 0xFFFF }
-    core 2 finished t1 { $pc = 0xFFFF }
     core 2 runs t2 { $pc=0x1234 $sp=0x7EB6 srcfile="k1/main.c" }
     core 3 runs t3 { $pc=0x1234 $sp=0x7D78 srcfile="k1/main.c" }
     core 4 runs t4 { $pc=0x1234 $sp=0x7E44 srcfile="k1/main.c" }
 }
 
 step 4 {
-    core 1 runs t5 { $pc=0x1234 $sp=0x7F00 srcfile="k1/main.c" }
     core 2 finished t2 { $pc = 0xFFFF }
+    core 1 runs t5 { $pc=0x1234 $sp=0x7F00 srcfile="k1/main.c" }
     core 3 runs t3 { $pc=0x1234 $sp=0x7E02 srcfile="k1/main.c" }
-    core 4 finished t4 { $pc = 0xFFFF }
 }
 
 step 5 {
-    core 1 finished t5 { $pc = 0xFFFF }
-    core 2 finished t2 { $pc = 0xFFFF }
-    core 3 finished t3 { $pc = 0xFFFF }
     core 4 runs t6 { $pc=0x1234 $sp=0x7FF0 srcfile="k1/main.c" }
 }
+


### PR DESCRIPTION
I am thinking that the "finished" state could be interpreted as
"task finished executing, waiting for other tasks to reach my
barrier". From a debug POV, it's code and data are still on the
physical core, so it makes sense to show it in the multicore
view. However other tasks that have finished before, over a
previous barrier, their core has been freed and may have been
re-allocated to something else.

I have cleaned-up the example to reflect this; i.e. removed
"finished" tasks from previous barriers.