### PR TITLE
[server] Added WebSocket endpoint for LSP

### DIFF
--- a/server/xtext-diagram/src/main/java/io/typefox/sprotty/server/xtext/websocket/LanguageMessageHandler.xtend
+++ b/server/xtext-diagram/src/main/java/io/typefox/sprotty/server/xtext/websocket/LanguageMessageHandler.xtend
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.typefox.sprotty.server.xtext.websocket
+
+import java.io.ByteArrayInputStream
+import java.io.FilterInputStream
+import java.io.IOException
+import java.nio.charset.Charset
+import java.util.List
+import javax.websocket.MessageHandler
+import org.eclipse.lsp4j.jsonrpc.RemoteEndpoint
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+
+@FinalFieldsConstructor
+class LanguageMessageHandler implements MessageHandler.Partial<String> {
+	
+	val StreamMessageProducer messageProducer
+	val RemoteEndpoint serverEndpoint
+	val List<byte[]> messages = newArrayList
+	
+	override onMessage(String partialMessage, boolean last) {
+		if (partialMessage.length > 0) {
+			messages.add(partialMessage.getBytes(Charset.forName('UTF-8')))
+		}
+		if (last && !messages.empty) {
+			messageProducer.input = new PartialMessageInputStream(messages)
+			messageProducer.listen(serverEndpoint)
+			messages.clear()
+		}
+	}
+	
+	protected static class PartialMessageInputStream extends FilterInputStream {
+		
+		val List<byte[]> messages
+		
+		int currentMessageIndex = 0
+	
+		protected new(List<byte[]> messages) {
+			super(new ByteArrayInputStream(messages.head))
+			this.messages = messages
+		}
+		
+		protected def boolean nextMessage() {
+			currentMessageIndex++
+			if (currentMessageIndex < messages.size) {
+				in = new ByteArrayInputStream(messages.get(currentMessageIndex))
+				return true
+			} else {
+				return false
+			}
+		}
+		
+		override available() throws IOException {
+			val current = super.available()
+			if (current <= 0 && nextMessage) {
+				return super.available()
+			} else {
+				return current
+			}
+		}
+		
+		override read() throws IOException {
+			val current = super.read()
+			if (current < 0 && nextMessage) {
+				return super.read()
+			} else {
+				return current
+			}
+		}
+		
+		override read(byte[] b) throws IOException {
+			val current = super.read(b)
+			if (current <= 0 && nextMessage) {
+				return super.read(b)
+			} else {
+				return current
+			}
+		}
+		
+		override read(byte[] b, int off, int len) throws IOException {
+			val current = super.read(b, off, len)
+			if (current <= 0 && nextMessage) {
+				return super.read(b, off, len)
+			} else {
+				return current
+			}
+		}
+		
+		override markSupported() {
+			false
+		}
+		
+	}
+	
+}

--- a/server/xtext-diagram/src/main/java/io/typefox/sprotty/server/xtext/websocket/LanguageServerEndpoint.xtend
+++ b/server/xtext-diagram/src/main/java/io/typefox/sprotty/server/xtext/websocket/LanguageServerEndpoint.xtend
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.typefox.sprotty.server.xtext.websocket
+
+import com.google.inject.Inject
+import io.typefox.sprotty.server.json.ActionTypeAdapter
+import java.util.LinkedHashMap
+import javax.websocket.Endpoint
+import javax.websocket.EndpointConfig
+import javax.websocket.Session
+import org.eclipse.lsp4j.jsonrpc.RemoteEndpoint
+import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod
+import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethodProvider
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer
+import org.eclipse.lsp4j.jsonrpc.services.ServiceEndpoints
+import org.eclipse.lsp4j.services.LanguageClient
+import org.eclipse.lsp4j.services.LanguageClientAware
+import org.eclipse.lsp4j.services.LanguageServer
+
+class LanguageServerEndpoint extends Endpoint {
+	
+	@Inject LanguageServer languageServer
+	
+	override onOpen(Session session, EndpointConfig config) {
+		val supportedMethods = new LinkedHashMap<String, JsonRpcMethod>
+		supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(LanguageClient))
+		if (languageServer instanceof JsonRpcMethodProvider)
+			supportedMethods.putAll(languageServer.supportedMethods)
+		
+		val jsonHandler = new MessageJsonHandler(supportedMethods) {
+			override getDefaultGsonBuilder() {
+				ActionTypeAdapter.configureGson(super.defaultGsonBuilder)
+			}
+		}
+		val outgoingMessageStream = new WebSocketMessageConsumer(session.asyncRemote, jsonHandler)
+		val serverEndpoint = new RemoteEndpoint(outgoingMessageStream, ServiceEndpoints.toEndpoint(languageServer))
+		jsonHandler.setMethodProvider(serverEndpoint)
+		val incomingMessageStream = new StreamMessageProducer(null, jsonHandler)
+		session.addMessageHandler(new LanguageMessageHandler(incomingMessageStream, serverEndpoint))
+		
+		val remoteProxy = ServiceEndpoints.toServiceObject(serverEndpoint, LanguageClient)
+		if (languageServer instanceof LanguageClientAware)
+			languageServer.connect(remoteProxy)
+	}
+	
+}

--- a/server/xtext-diagram/src/main/java/io/typefox/sprotty/server/xtext/websocket/WebSocketMessageConsumer.xtend
+++ b/server/xtext-diagram/src/main/java/io/typefox/sprotty/server/xtext/websocket/WebSocketMessageConsumer.xtend
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.typefox.sprotty.server.xtext.websocket
+
+import java.io.ByteArrayOutputStream
+import javax.websocket.RemoteEndpoint
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer
+import org.eclipse.lsp4j.jsonrpc.messages.Message
+
+class WebSocketMessageConsumer extends StreamMessageConsumer {
+	
+	val RemoteEndpoint.Async remote
+	
+	new(RemoteEndpoint.Async remote, MessageJsonHandler jsonHandler) {
+		super(new ByteArrayOutputStream, jsonHandler)
+		this.remote = remote
+	}
+	
+	new(RemoteEndpoint.Async remote, String encoding, MessageJsonHandler jsonHandler) {
+		super(new ByteArrayOutputStream, encoding, jsonHandler)
+		this.remote = remote
+	}
+	
+	override consume(Message message) {
+		super.consume(message)
+		val out = output as ByteArrayOutputStream
+		remote.sendText(out.toString)
+		out.reset()
+	}
+	
+}


### PR DESCRIPTION
Added an endpoint implementation for using sprotty with Xtext via a WebSocket.

Note that the code for the MessageHandler implementation would be simpler if we just concatenate all partial messages with a StringBuilder, but I chose the more efficient way of multiplexing an input stream over all message parts.