### PR TITLE
[export] only export CSS files with a given comment

### DIFF
--- a/client/css/sprotty.css
+++ b/client/css/sprotty.css
@@ -5,6 +5,8 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
+/* sprotty SVG export */
+ 
 .sprotty {
     padding: 0px;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/client/examples/circlegraph/css/diagram.css
+++ b/client/examples/circlegraph/css/diagram.css
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* sprotty SVG export */
+ 
 .node {
     fill: #aae;
     stroke: #66b;

--- a/client/examples/circlegraph/css/page.css
+++ b/client/examples/circlegraph/css/page.css
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+ 
 .copyright {
     margin-top: 10px;
     text-align: right;

--- a/client/examples/classdiagram/css/diagram.css
+++ b/client/examples/classdiagram/css/diagram.css
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* sprotty SVG export */
+ 
 .node {
     fill: #cdc;
     stroke: #152;

--- a/client/examples/classdiagram/css/page.css
+++ b/client/examples/classdiagram/css/page.css
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 .copyright {
     margin-top: 10px;
     text-align: right;

--- a/client/examples/flow/css/diagram.css
+++ b/client/examples/flow/css/diagram.css
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* sprotty SVG export */
+ 
 .node {
     stroke: #444;
     stroke-width: 1;

--- a/client/examples/flow/css/page.css
+++ b/client/examples/flow/css/page.css
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+ 
 .row {
     margin-bottom: 15px;
 }

--- a/client/examples/multicore/css/diagram.css
+++ b/client/examples/multicore/css/diagram.css
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* sprotty SVG export */
+ 
 .core {
     stroke: #666;
     stroke-width: 1;

--- a/client/examples/multicore/css/page.css
+++ b/client/examples/multicore/css/page.css
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 .row {
     margin-bottom: 15px;
 }

--- a/client/examples/svg/css/diagram.css
+++ b/client/examples/svg/css/diagram.css
@@ -1,3 +1,12 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/* sprotty SVG export */
+ 
 .missing {
     stroke-width: 1;
     stroke: #f00;

--- a/client/examples/svg/css/page.css
+++ b/client/examples/svg/css/page.css
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
 .copyright {
     margin-top: 10px;
     text-align: right;

--- a/client/src/features/export/svg-exporter.ts
+++ b/client/src/features/export/svg-exporter.ts
@@ -92,8 +92,13 @@ export class SvgExporter {
         return style
     }
 
+    /**
+     * By default, only CSS rules from files with a given comment are exported.
+     */
     protected isExported(styleSheet: CSSStyleSheet) {
-        return true
+        return styleSheet.ownerNode
+            && (styleSheet.ownerNode as any).innerHTML
+            && (styleSheet.ownerNode as any).innerHTML.indexOf('/* sprotty SVG export */') !== -1
     }
 
     protected getBounds(root: SModelRoot) {


### PR DESCRIPTION
When used in Theia, CSS files are imported vie TypeScript imports. As such, they don't provide a href wen inspected by the export. I added a marker comment for CSS files that should be included.