### PR TITLE
[viewer] make KeyTool configurable

### DIFF
--- a/client/src/base/di.config.ts
+++ b/client/src/base/di.config.ts
@@ -98,9 +98,13 @@ let defaultContainerModule = new ContainerModule(bind => {
     })
 
     // Tools & Decorators --------------------------------------
+    bind(KeyTool).toSelf().inSingletonScope()
+    bind(MouseTool).toSelf().inSingletonScope()
     bind(TYPES.IVNodeDecorator).to(IdDecorator).inSingletonScope()
-    bind(TYPES.IVNodeDecorator).to(MouseTool).inSingletonScope()
-    bind(TYPES.IVNodeDecorator).to(KeyTool).inSingletonScope()
+    bind(TYPES.IVNodeDecorator).toDynamicValue(context => 
+        context.container.get(MouseTool)).inSingletonScope
+    bind(TYPES.IVNodeDecorator).toDynamicValue(context => 
+        context.container.get(KeyTool)).inSingletonScope
     bind(TYPES.IVNodeDecorator).to(FocusFixDecorator).inSingletonScope()
     bind(TYPES.PopupVNodeDecorator).to(IdDecorator).inSingletonScope()
     bind(TYPES.PopupVNodeDecorator).to(PopupMouseTool).inSingletonScope()


### PR DESCRIPTION
Trying to disable the KeyTool in Theia I found out that I cannot rebind it as it is currently consumed by a multi-binding.
Naming the binding neither works, as rebinding a named binding rebinds all bindings with the same service identifier, not just the one with the same name.
So I went the Theia-way for two-staged binding wit a dynamic binding.