### PR TITLE
Transfer client options to the server

### DIFF
--- a/client/examples/flow/src/flow-server.ts
+++ b/client/examples/flow/src/flow-server.ts
@@ -46,7 +46,10 @@ export function setupFlow(websocket: WebSocket) {
             if (xtextServices !== undefined) {
                 const resourceId = xtextServices.options.resourceId
                 diagramServer.clientId = resourceId + '_flow'
-                diagramServer.handle(new RequestModelAction({ resourceId }))
+                diagramServer.handle(new RequestModelAction({
+                    resourceId: resourceId,
+                    needsClientLayout: 'false'
+                }))
             } else {
                 setTimeout(run, 50)
             }

--- a/client/examples/multicore/src/multicore-server.ts
+++ b/client/examples/multicore/src/multicore-server.ts
@@ -46,7 +46,10 @@ export function setupMulticore(websocket: WebSocket) {
             if (xtextServices !== undefined) {
                 const resourceId = xtextServices.options.resourceId
                 diagramServer.clientId = resourceId + '_processor'
-                diagramServer.handle(new RequestModelAction({ resourceId }))
+                diagramServer.handle(new RequestModelAction({
+                    resourceId: resourceId,
+                    needsClientLayout: 'true'
+                }))
             } else {
                 setTimeout(run, 50)
             }

--- a/client/src/base/features/initialize-canvas.ts
+++ b/client/src/base/features/initialize-canvas.ts
@@ -66,7 +66,7 @@ export class CanvasBoundsInitializer implements IVNodeDecorator {
 export class InitializeCanvasBoundsAction implements Action {
     readonly kind = InitializeCanvasBoundsCommand.KIND
 
-    constructor(public newCanvasBounds: Bounds) {
+    constructor(public readonly newCanvasBounds: Bounds) {
     }
 }
 

--- a/client/src/base/features/set-model.ts
+++ b/client/src/base/features/set-model.ts
@@ -21,7 +21,7 @@ export class RequestModelAction implements Action {
     static readonly KIND = 'requestModel'
     readonly kind = RequestModelAction.KIND
 
-    constructor(public options?: { [key: string]: string }) {
+    constructor(public readonly options?: { [key: string]: string }) {
     }
 }
 
@@ -31,7 +31,8 @@ export class RequestModelAction implements Action {
 export class SetModelAction implements Action {
     readonly kind = SetModelCommand.KIND
 
-    constructor(public newRoot: SModelRootSchema, public isInitial: boolean = false) {
+    constructor(public readonly newRoot: SModelRootSchema,
+                public readonly isInitial: boolean = false) {
     }
 }
 

--- a/client/src/base/features/set-model.ts
+++ b/client/src/base/features/set-model.ts
@@ -21,7 +21,7 @@ export class RequestModelAction implements Action {
     static readonly KIND = 'requestModel'
     readonly kind = RequestModelAction.KIND
 
-    constructor(public readonly options?: { [key: string]: string }) {
+    constructor(public options?: { [key: string]: string }) {
     }
 }
 

--- a/client/src/features/bounds/bounds-manipulation.ts
+++ b/client/src/features/bounds/bounds-manipulation.ts
@@ -18,7 +18,7 @@ import { BoundsAware, isBoundsAware, Alignable } from './model'
 export class SetBoundsAction implements Action {
     readonly kind = SetBoundsCommand.KIND
 
-    constructor(public bounds: ElementAndBounds[]) {
+    constructor(public readonly bounds: ElementAndBounds[]) {
     }
 }
 
@@ -31,7 +31,7 @@ export class SetBoundsAction implements Action {
 export class RequestBoundsAction implements Action {
     readonly kind = RequestBoundsCommand.KIND
 
-    constructor(public newRoot: SModelRootSchema) {
+    constructor(public readonly newRoot: SModelRootSchema) {
     }
 }
 
@@ -47,7 +47,9 @@ export class ComputedBoundsAction implements Action {
 
     readonly kind = ComputedBoundsAction.KIND
 
-    constructor(public bounds: ElementAndBounds[], public revision?: number, public alignments?: ElementAndAlignment[]) {
+    constructor(public readonly bounds: ElementAndBounds[],
+                public readonly revision?: number,
+                public readonly alignments?: ElementAndAlignment[]) {
     }
 }
 

--- a/client/src/features/hover/hover.ts
+++ b/client/src/features/hover/hover.ts
@@ -68,7 +68,7 @@ export class RequestPopupModelAction implements Action {
     static readonly KIND = 'requestPopupModel'
     readonly kind = RequestPopupModelAction.KIND
 
-    constructor(public elementId: string, public bounds: Bounds) {
+    constructor(public readonly elementId: string, public readonly bounds: Bounds) {
     }
 }
 
@@ -79,7 +79,7 @@ export class RequestPopupModelAction implements Action {
 export class SetPopupModelAction implements Action {
     readonly kind = SetPopupModelCommand.KIND
 
-    constructor(public newRoot: SModelRootSchema) {
+    constructor(public readonly newRoot: SModelRootSchema) {
     }
 }
 

--- a/client/src/features/select/select.ts
+++ b/client/src/features/select/select.ts
@@ -28,6 +28,7 @@ import { SButton } from '../button/model'
  */
 export class SelectAction implements Action {
     kind = SelectCommand.KIND
+    // TODO An action should not have mutable properties
     selectAll: boolean = false
     deselectAll: boolean = false
 

--- a/client/src/features/update/update-model.ts
+++ b/client/src/features/update/update-model.ts
@@ -30,7 +30,7 @@ export class UpdateModelAction implements Action {
     matches?: Match[]
     animate?: boolean = true
 
-    constructor(public newRoot?: SModelRootSchema) {
+    constructor(public readonly newRoot?: SModelRootSchema) {
     }
 }
 

--- a/client/src/model-source/logging.ts
+++ b/client/src/model-source/logging.ts
@@ -15,8 +15,11 @@ export class LoggingAction implements Action {
     static readonly KIND = 'logging'
     readonly kind = LoggingAction.KIND
 
-    constructor(public severity: string, public time: string, public caller: string,
-        public message: string, public params: string[]) {
+    constructor(public readonly severity: string,
+                public readonly time: string,
+                public readonly caller: string,
+                public readonly message: string,
+                public readonly params: string[]) {
     }
 }
 

--- a/server/diagram-api/src/main/java/io/typefox/sprotty/api/DefaultDiagramServer.java
+++ b/server/diagram-api/src/main/java/io/typefox/sprotty/api/DefaultDiagramServer.java
@@ -294,8 +294,12 @@ public class DefaultDiagramServer implements IDiagramServer {
 	 * Called when a {@code RequestModelAction} is received.
 	 */
 	protected void handle(RequestModelAction request) {
-		if (request.getOptions() != null) {
-			setOptions(request.getOptions());
+		Map<String, String> options = request.getOptions();
+		if (options != null) {
+			setOptions(options);
+			String needsClientLayout = options.get("needsClientLayout");
+			if (needsClientLayout != null && !needsClientLayout.isEmpty())
+				setNeedsClientLayout(Boolean.parseBoolean(needsClientLayout));
 		}
 		SModelRoot model = getModel();
 		if (model != null) {

--- a/server/xtext-diagram-examples/io.typefox.sprotty.example.multicore.web/src/main/java/io/typefox/sprotty/example/multicore/web/diagram/MulticoreAllocationDiagramServer.xtend
+++ b/server/xtext-diagram-examples/io.typefox.sprotty.example.multicore.web/src/main/java/io/typefox/sprotty/example/multicore/web/diagram/MulticoreAllocationDiagramServer.xtend
@@ -21,13 +21,6 @@ class MulticoreAllocationDiagramServer extends DefaultDiagramServer {
 	@Accessors
 	BiMap<EObject, SModelElement> modelMapping
 	
-	override protected needsClientLayout(SModelRoot root) {
-		switch root.type {
-			case 'processor': true
-			default: false
-		}
-	}
-	
 	override protected needsServerLayout(SModelRoot root) {
 		switch root.type {
 			case 'flow': true


### PR DESCRIPTION
Fixes #162. With this change the options configured in the client are sent to the server with every RequestModelAction.