### PR TITLE
Implemented removal of edge routing points

### DIFF
--- a/client/examples/flow/src/views.tsx
+++ b/client/examples/flow/src/views.tsx
@@ -7,7 +7,7 @@
 
 import { VNode } from "snabbdom/vnode";
 import {
-    RenderingContext, SEdge, PolylineEdgeView, CircularNodeView, RectangularNodeView, angle, Point, toDegrees,
+    RenderingContext, SEdge, PolylineEdgeView, CircularNodeView, RectangularNodeView, angleOfPoint, Point, toDegrees,
     RGBColor, toSVG, rgb
 } from "../../../src";
 import * as snabbdom from "snabbdom-jsx";
@@ -48,7 +48,7 @@ export class FlowEdgeView extends PolylineEdgeView {
         const p2 = segments[segments.length - 1];
         return [
             <path class-sprotty-edge={true} class-arrow={true} d="M 0,0 L 10,-4 L 10,4 Z"
-                  transform={`rotate(${toDegrees(angle(p2, p1))} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`}/>
+                  transform={`rotate(${toDegrees(angleOfPoint({ x: p1.x - p2.x, y: p1.y - p2.y }))} ${p2.x} ${p2.y}) translate(${p2.x} ${p2.y})`}/>
         ];
     }
 }

--- a/client/src/features/edit/model.ts
+++ b/client/src/features/edit/model.ts
@@ -5,8 +5,8 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { Point } from '../../utils/geometry';
-import { SModelElement, SChildElement } from '../../base/model/smodel';
+import { Point, angleBetweenPoints } from '../../utils/geometry';
+import { SModelElement, SChildElement, SParentElement } from '../../base/model/smodel';
 import { SModelExtension } from '../../base/model/smodel-extension';
 import { Selectable, selectFeature } from '../select/model';
 import { moveFeature } from '../move/model';
@@ -35,6 +35,8 @@ export class SRoutingHandle extends SChildElement implements Selectable, Hoverab
     kind: 'junction' | 'line';
     /** The actual routing point index (junction) or the previous point index (line). */
     pointIndex: number;
+    /** Whether the routing point is being dragged. */
+    editMode: boolean = false;
 
     hoverFeedback: boolean = false;
     selected: boolean = false;
@@ -42,4 +44,37 @@ export class SRoutingHandle extends SChildElement implements Selectable, Hoverab
     hasFeature(feature: symbol): boolean {
         return feature === selectFeature || feature === moveFeature || feature === hoverFeedbackFeature;
     }
+}
+
+/** The angle in radians below which a routing handle is removed. */
+const HANDLE_REMOVE_THRESHOLD = 0.1;
+
+/**
+ * Remove routed points that are in edit mode and for which the angle between the preceding and
+ * following points falls below a threshold.
+ */
+export function filterEditModeHandles(route: RoutedPoint[], parent: SParentElement): RoutedPoint[] {
+    if (parent.children.length === 0)
+        return route;
+
+    let i = 0;
+    while (i < route.length) {
+        const curr = route[i];
+        if (curr.pointIndex !== undefined) {
+            const handle: SRoutingHandle | undefined = parent.children.find(child =>
+                child instanceof SRoutingHandle && child.kind === 'junction' && child.pointIndex === curr.pointIndex) as any;
+            if (handle !== undefined && handle.editMode && i > 0 && i < route.length - 1) {
+                const prev = route[i - 1], next = route[i + 1];
+                const prevDiff: Point = { x: prev.x - curr.x, y: prev.y - curr.y };
+                const nextDiff: Point = { x: next.x - curr.x, y: next.y - curr.y };
+                const angle = angleBetweenPoints(prevDiff, nextDiff);
+                if (Math.abs(Math.PI - angle) < HANDLE_REMOVE_THRESHOLD) {
+                    route.splice(i, 1);
+                    continue;
+                }
+            }
+        }
+        i++;
+    }
+    return route;
 }

--- a/client/src/features/select/select.ts
+++ b/client/src/features/select/select.ts
@@ -51,6 +51,7 @@ export class SelectAllAction implements Action {
 
 export type ElementSelection = {
     element: SChildElement
+    parent: SParentElement
     index: number
 };
 
@@ -70,7 +71,8 @@ export class SelectCommand extends Command {
             const element = model.index.getById(id);
             if (element instanceof SChildElement && isSelectable(element)) {
                 this.selected.push({
-                    element: element,
+                    element,
+                    parent: element.parent,
                     index: element.parent.children.indexOf(element)
                 });
             }
@@ -79,7 +81,8 @@ export class SelectCommand extends Command {
             const element = model.index.getById(id);
             if (element instanceof SChildElement && isSelectable(element)) {
                 this.deselected.push({
-                    element: element,
+                    element,
+                    parent: element.parent,
                     index: element.parent.children.indexOf(element)
                 });
             }
@@ -93,7 +96,7 @@ export class SelectCommand extends Command {
             const element = selection.element;
             if (isSelectable(element))
                 element.selected = false;
-            element.parent.move(element, selection.index);
+            selection.parent.move(element, selection.index);
         }
         this.deselected.reverse().forEach(selection => {
             if (isSelectable(selection.element))
@@ -106,8 +109,8 @@ export class SelectCommand extends Command {
         for (let i = 0; i < this.selected.length; ++i) {
             const selection = this.selected[i];
             const element = selection.element;
-            const childrenLength = element.parent.children.length;
-            element.parent.move(element, childrenLength - 1);
+            const childrenLength = selection.parent.children.length;
+            selection.parent.move(element, childrenLength - 1);
         }
         this.deselected.forEach(selection => {
             if (isSelectable(selection.element))

--- a/client/src/graph/sgraph.ts
+++ b/client/src/graph/sgraph.ts
@@ -19,7 +19,7 @@ import { Selectable, selectFeature } from '../features/select/model';
 import { ViewportRootElement } from '../features/viewport/viewport-root';
 import { Bounds, ORIGIN_POINT, Point, center } from '../utils/geometry';
 import { SShapeElement, SShapeElementSchema } from '../features/bounds/model';
-import { editFeature, Routable } from '../features/edit/model';
+import { editFeature, Routable, filterEditModeHandles } from '../features/edit/model';
 import { translatePoint } from '../base/model/smodel-utils';
 import { RoutedPoint, linearRoute } from './routing';
 
@@ -188,7 +188,8 @@ export class SEdge extends SChildElement implements Fadeable, Selectable, Routab
     }
 
     route(): RoutedPoint[] {
-        return linearRoute(this);
+        const route = linearRoute(this);
+        return filterEditModeHandles(route, this);
     }
 
     hasFeature(feature: symbol): boolean {

--- a/client/src/graph/views.tsx
+++ b/client/src/graph/views.tsx
@@ -85,43 +85,51 @@ export class SRoutingHandleView implements IView {
 
     protected getPosition(handle: SRoutingHandle, route: RoutedPoint[]): Point | undefined {
         if (handle.kind === 'line') {
-            const parent = handle.parent;
-            if (isRoutable(parent)) {
-                const getIndex = (rp: RoutedPoint) => {
-                    if (rp.pointIndex !== undefined)
-                        return rp.pointIndex;
-                    else if (rp.kind === 'target')
-                        return parent.routingPoints.length;
-                    else
-                        return -1;
-                };
-                let rp1, rp2: RoutedPoint | undefined;
-                for (const rp of route) {
-                    const i = getIndex(rp);
-                    if (i <= handle.pointIndex && (rp1 === undefined || i > getIndex(rp1)))
-                        rp1 = rp;
-                    if (i > handle.pointIndex && (rp2 === undefined || i < getIndex(rp2)))
-                        rp2 = rp;
-                }
-                if (rp1 !== undefined && rp2 !== undefined) {
-                    // Skip this handle if its related line segment is not included in the route
-                    if (getIndex(rp1) !== handle.pointIndex && handle.pointIndex >= 0) {
-                        const point = parent.routingPoints[handle.pointIndex];
-                        if (maxDistance(point, rp1) >= maxDistance(point, rp2))
-                            return undefined;
-                    }
-                    if (getIndex(rp2) !== handle.pointIndex + 1 && handle.pointIndex + 1 < parent.routingPoints.length) {
-                        const point = parent.routingPoints[handle.pointIndex + 1];
-                        if (maxDistance(point, rp1) < maxDistance(point, rp2))
-                            return undefined;
-                    }
-                    // Skip this handle if its related line segment is too short
-                    if (maxDistance(rp1, rp2) >= this.minimalPointDistance)
-                        return centerOfLine(rp1, rp2);
-                }
-            }
+            return this.getLinePosition(handle, route);
         } else {
-            return route.find(rp => rp.pointIndex === handle.pointIndex);
+            return this.getJunctionPosition(handle, route);
+        }
+    }
+
+    protected getJunctionPosition(handle: SRoutingHandle, route: RoutedPoint[]): Point | undefined {
+        return route.find(rp => rp.pointIndex === handle.pointIndex);
+    }
+
+    protected getLinePosition(handle: SRoutingHandle, route: RoutedPoint[]): Point | undefined {
+        const parent = handle.parent;
+        if (isRoutable(parent)) {
+            const getIndex = (rp: RoutedPoint) => {
+                if (rp.pointIndex !== undefined)
+                    return rp.pointIndex;
+                else if (rp.kind === 'target')
+                    return parent.routingPoints.length;
+                else
+                    return -1;
+            };
+            let rp1, rp2: RoutedPoint | undefined;
+            for (const rp of route) {
+                const i = getIndex(rp);
+                if (i <= handle.pointIndex && (rp1 === undefined || i > getIndex(rp1)))
+                    rp1 = rp;
+                if (i > handle.pointIndex && (rp2 === undefined || i < getIndex(rp2)))
+                    rp2 = rp;
+            }
+            if (rp1 !== undefined && rp2 !== undefined) {
+                // Skip this handle if its related line segment is not included in the route
+                if (getIndex(rp1) !== handle.pointIndex && handle.pointIndex >= 0) {
+                    const point = parent.routingPoints[handle.pointIndex];
+                    if (maxDistance(point, rp1) >= maxDistance(point, rp2))
+                        return undefined;
+                }
+                if (getIndex(rp2) !== handle.pointIndex + 1 && handle.pointIndex + 1 < parent.routingPoints.length) {
+                    const point = parent.routingPoints[handle.pointIndex + 1];
+                    if (maxDistance(point, rp1) < maxDistance(point, rp2))
+                        return undefined;
+                }
+                // Skip this handle if its related line segment is too short
+                if (maxDistance(rp1, rp2) >= this.minimalPointDistance)
+                    return centerOfLine(rp1, rp2);
+            }
         }
         return undefined;
     }

--- a/client/src/utils/geometry.spec.ts
+++ b/client/src/utils/geometry.spec.ts
@@ -7,39 +7,52 @@
 
 import "mocha";
 import { expect } from "chai";
-import { almostEquals, euclideanDistance, manhattanDistance, Bounds, combine, includes, ORIGIN_POINT } from "./geometry";
+import { almostEquals, euclideanDistance, manhattanDistance, Bounds, combine, includes, ORIGIN_POINT, angleBetweenPoints } from "./geometry";
 
-describe('euclideanDistance', () => {
-    it('works as expected', () => {
-        expect(euclideanDistance({x: 0, y: 0}, {x: 3, y: 4})).to.equal(5);
+describe('geometry', () => {
+    describe('euclideanDistance', () => {
+        it('works as expected', () => {
+            expect(euclideanDistance({x: 0, y: 0}, {x: 3, y: 4})).to.equal(5);
+        });
     });
-});
 
-describe('manhattanDistance', () => {
-    it('works as expected', () => {
-        expect(manhattanDistance({x: 0, y: 0}, {x: 3, y: 4})).to.equal(7);
+    describe('manhattanDistance', () => {
+        it('works as expected', () => {
+            expect(manhattanDistance({x: 0, y: 0}, {x: 3, y: 4})).to.equal(7);
+        });
     });
-});
 
-describe('almostEquals', () => {
-    it('returns false for clearly different values', () => {
-        expect(almostEquals(3, 17)).to.be.false;
+    describe('almostEquals', () => {
+        it('returns false for clearly different values', () => {
+            expect(almostEquals(3, 17)).to.be.false;
+        });
+        it('returns true for almost equal values', () => {
+            expect(almostEquals(3.12895, 3.12893)).to.be.true;
+        });
     });
-    it('returns true for almost equal values', () => {
-        expect(almostEquals(3.12895, 3.12893)).to.be.true;
-    });
-});
 
-describe('combine', () => {
-    it('includes all corner points of the input bounds', () => {
-        const b0: Bounds = { x: 2, y: 2, width: 4, height: 6 };
-        const b1: Bounds = { x: 5, y: 3, width: 5, height: 10 };
-        const b2 = combine(b0, b1);
-        expect(includes(b2, b0)).to.be.true;
-        expect(includes(b2, b1)).to.be.true;
-        expect(includes(b2, { x: b0.x + b0.width, y: b0.y + b0.height })).to.be.true;
-        expect(includes(b2, { x: b1.x + b1.width, y: b1.y + b1.height })).to.be.true;
-        expect(includes(b2, ORIGIN_POINT)).to.be.false;
-        expect(includes(b2, { x: 100, y: 100 })).to.be.false;
+    describe('combine', () => {
+        it('includes all corner points of the input bounds', () => {
+            const b0: Bounds = { x: 2, y: 2, width: 4, height: 6 };
+            const b1: Bounds = { x: 5, y: 3, width: 5, height: 10 };
+            const b2 = combine(b0, b1);
+            expect(includes(b2, b0)).to.be.true;
+            expect(includes(b2, b1)).to.be.true;
+            expect(includes(b2, { x: b0.x + b0.width, y: b0.y + b0.height })).to.be.true;
+            expect(includes(b2, { x: b1.x + b1.width, y: b1.y + b1.height })).to.be.true;
+            expect(includes(b2, ORIGIN_POINT)).to.be.false;
+            expect(includes(b2, { x: 100, y: 100 })).to.be.false;
+        });
+    });
+
+    describe('angleBetweenPoints', () => {
+        it('computes a 90° angle correctly', () => {
+            expect(angleBetweenPoints({ x: 2, y: 0 }, { x: 0, y: 3 })).to.equal(Math.PI / 2);
+            expect(angleBetweenPoints({ x: 2, y: 0 }, { x: 0, y: -3 })).to.equal(Math.PI / 2);
+        });
+        it('computes a 180° angle correctly', () => {
+            expect(angleBetweenPoints({ x: 2, y: 0 }, { x: -3, y: 0 })).to.equal(Math.PI);
+            expect(angleBetweenPoints({ x: 0, y: 2 }, { x: 0, y: -3 })).to.equal(Math.PI);
+        });
     });
 });

--- a/client/src/utils/geometry.ts
+++ b/client/src/utils/geometry.ts
@@ -201,9 +201,27 @@ export function maxDistance(a: Point, b: Point): number {
     return Math.max(Math.abs(b.x - a.x), Math.abs(b.y - a.y));
 }
 
-// range (-PI, PI]
-export function angle(a: Point, b: Point): number {
-    return Math.atan2(b.y - a.y, b.x - a.x);
+/**
+ * Computes the angle in radians of the given point to the x-axis of the coordinate system.
+ * The result is in the range [-pi, pi].
+ * @param {Point} p - A point in the Eucledian plane
+ */
+export function angleOfPoint(p: Point): number {
+    return Math.atan2(p.y, p.x);
+}
+
+/**
+ * Computes the angle in radians between the two given points (relative to the origin of the coordinate system).
+ * The result is in the range [0, pi]. Returns NaN if the points are equal.
+ * @param {Point} a - First point
+ * @param {Point} b - Second point
+ */
+export function angleBetweenPoints(a: Point, b: Point): number {
+    const lengthProduct = Math.sqrt((a.x * a.x + a.y * a.y) * (b.x * b.x + b.y * b.y));
+    if (isNaN(lengthProduct) || lengthProduct === 0)
+        return NaN;
+    const dotProduct = a.x * b.x + a.y * b.y;
+    return Math.acos(dotProduct / lengthProduct);
 }
 
 /**


### PR DESCRIPTION
Fixes #206. Drag a routing point so it forms an almost straight line with its preceding and following points to remove it.

The idea: When the mouse button is pressed down on a routing handle, a new `editMode` flag is set on it using SwitchEditModeAction, and the flag is removed when the button is released. The check for the angle between neighboring points is done for handles that are in edit mode. When the `editMode` is switched off and the selected routing point is currently skipped, it is removed.

I also removed the check for the distance of neighboring points in the linear router since that was rather confusing while editing the routing. The check is still active for the source and target anchor.