### PR TITLE
[README] use GH url for the demo image

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ sprotty is a next-generation, open-source, web-based diagramming framework. Some
 * configuration via dependency injection,
 * integration with [Xtext, the Language Server Protocol and Theia](https://github.com/theia-ide/theia-sprotty-example) that can be run as rich-client as well as in the browser..
 
-[![sprotty demo](./sprotty_demo_screenshot.png)](http://www.youtube.com/watch?v=IydM4l7WFKk "sprotty demo")
+[![sprotty demo](https://raw.githubusercontent.com/theia-ide/sprotty/master/sprotty_demo_screenshot.png)](http://www.youtube.com/watch?v=IydM4l7WFKk "sprotty demo")
 
 ## Getting started
 


### PR DESCRIPTION
it is [recommended](https://stackoverflow.com/a/14494775/1783092) to use GH raw urls, or use any other hosting service (e.g. GH pages.) if the REAMDE.md is displayed on other sites (like npm) the relative links might be broken.