### PR TITLE
Enhanced LocalModelSource and ActionDispatcher API to return promises

### DIFF
--- a/client/src/base/commands/command.ts
+++ b/client/src/base/commands/command.ts
@@ -31,7 +31,11 @@ import { TYPES } from "../types";
  * rather inherit from one of its abstract implementators.
  */
 export interface ICommand {
-    readonly blockUntilActionKind?: string
+    /**
+     * If this property is present, all following actions are blocked
+     * until the function returns `true`.
+     */
+    readonly blockUntil?: (action: Action) => boolean;
 
     execute(context: CommandExecutionContext): CommandResult
 

--- a/client/src/base/features/set-model.ts
+++ b/client/src/base/features/set-model.ts
@@ -59,7 +59,7 @@ export class SetModelCommand extends Command {
         return this.newRoot;
     }
 
-    get blockUntilActionKind() {
-        return InitializeCanvasBoundsCommand.KIND;
+    get blockUntil(): (action: Action) => boolean {
+        return action => action.kind === InitializeCanvasBoundsCommand.KIND;
     }
 }

--- a/client/src/graph/routing.ts
+++ b/client/src/graph/routing.ts
@@ -15,9 +15,13 @@ export interface RoutedPoint extends Point {
 
 export type EdgeRouter = (edge: SEdge) => RoutedPoint[];
 
-const minimalPointDistance: number = 2;
 
-export function linearRoute(edge: SEdge): RoutedPoint[] {
+export interface LinearRouteOptions {
+    minimalPointDistance: number;
+}
+
+export function linearRoute(edge: SEdge,
+        options: LinearRouteOptions = { minimalPointDistance: 2 }): RoutedPoint[] {
     const source = edge.source;
     const target = edge.target;
     if (source === undefined || target === undefined) {
@@ -48,8 +52,8 @@ export function linearRoute(edge: SEdge): RoutedPoint[] {
     for (let i = 0; i < rpCount; i++) {
         const p = edge.routingPoints[i];
         if (i > 0 && i < rpCount - 1
-            || i === 0 && maxDistance(sourceAnchor, p) >= minimalPointDistance + (edge.sourceAnchorCorrection || 0)
-            || i === rpCount - 1 && maxDistance(p, targetAnchor) >= minimalPointDistance + (edge.targetAnchorCorrection || 0)) {
+            || i === 0 && maxDistance(sourceAnchor, p) >= options.minimalPointDistance + (edge.sourceAnchorCorrection || 0)
+            || i === rpCount - 1 && maxDistance(p, targetAnchor) >= options.minimalPointDistance + (edge.targetAnchorCorrection || 0)) {
             result.push({ kind: 'linear', x: p.x, y: p.y, pointIndex: i });
         }
     }

--- a/client/src/lib/svg-views.tsx
+++ b/client/src/lib/svg-views.tsx
@@ -49,7 +49,7 @@ export class RectangularNodeView implements IView {
         return <g>
             <rect class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
                   class-mouseover={node.hoverFeedback} class-selected={node.selected}
-                  x="0" y="0" width={node.size.width} height={node.size.height}></rect>
+                  x="0" y="0" width={Math.max(node.size.width, 0)} height={Math.max(node.size.height, 0)}></rect>
             {context.renderChildren(node)}
         </g>;
     }

--- a/client/src/model-source/diagram-server.ts
+++ b/client/src/model-source/diagram-server.ts
@@ -114,7 +114,9 @@ export abstract class DiagramServer extends ModelSource {
             if (!object.clientId || object.clientId === this.clientId) {
                 (object.action as any)[receivedFromServerProperty] = true;
                 this.logger.log(this, 'receiving', object);
-                this.actionDispatcher.dispatch(object.action, this.storeNewModel.bind(this));
+                this.actionDispatcher.dispatch(object.action).then(() => {
+                    this.storeNewModel(object.action);
+                });
             }
         } else {
             this.logger.error(this, 'received data is not an action message', object);

--- a/client/src/utils/async.ts
+++ b/client/src/utils/async.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2017 TypeFox and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Simple implementation of the deferred pattern.
+ * An object that exposes a promise and functions to resolve and reject it.
+ */
+export class Deferred<T> {
+    resolve: (value?: T | PromiseLike<T>) => void;
+    reject: (reason?: any) => void;
+
+    readonly promise = new Promise<T>((resolve, reject) => {
+        this.resolve = resolve;
+        this.reject = reject;
+    });
+}


### PR DESCRIPTION
While working on https://github.com/TypeFox/npm-dependency-graph I realized that we need a better way to interact with a LocalModelSource. With this change I can write code like

```typescript
this.loadIndicator(true);
// change the current model...
await this.updateModel();
this.loadIndicator(false);
```

In general, whenever an action is dispatched, I get a promise that is resolved when the effect is visible (i.e. the command has been executed and the viewer has updated the DOM).