### PR TITLE
 Add anchoring support for rotated rectangles #235

### DIFF
--- a/client/examples/circlegraph/circlegraph.html
+++ b/client/examples/circlegraph/circlegraph.html
@@ -15,9 +15,10 @@
     <div class="container">
         <div class="row" id="sprotty-app" data-app="circlegraph">
             <div class="col-md-10">
-                <h1>sprotty Circles Example</h1>
+                <h1>sprotty Circles and Rectangle Example</h1>
                 <p>
-                    <button id="addNode">Add node</button>
+                    <button id="addCircularNode">Add circular node</button>
+                    <button id="addRectangularNode">Add rectangular node</button>
                     <button id="scrambleNodes">Scramble nodes</button>
                 </p>
             </div>

--- a/client/examples/circlegraph/src/di.config.ts
+++ b/client/examples/circlegraph/src/di.config.ts
@@ -9,9 +9,10 @@ import { Container, ContainerModule } from "inversify";
 import {
     defaultModule, TYPES, configureViewerOptions, SGraphFactory, SGraphView, PolylineEdgeView, ConsoleLogger,
     LogLevel, WebSocketDiagramServer, boundsModule, moveModule, selectModule, undoRedoModule, viewportModule,
-    LocalModelSource, exportModule, CircularNode, configureModelElement, SGraph, SEdge
+    LocalModelSource, exportModule, CircularNode, configureModelElement, SGraph, SEdge, RotatedRectangularNodeView
 } from "../../../src";
 import { CircleNodeView } from "./views";
+import { RhombusNode } from "./model";
 
 export default (useWebsocket: boolean) => {
     const circlegraphModule = new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -25,6 +26,7 @@ export default (useWebsocket: boolean) => {
         const context = { bind, unbind, isBound, rebind };
         configureModelElement(context, 'graph', SGraph, SGraphView);
         configureModelElement(context, 'node:circle', CircularNode, CircleNodeView);
+        configureModelElement(context, 'node:rectangle', RhombusNode, RotatedRectangularNodeView);
         configureModelElement(context, 'edge:straight', SEdge, PolylineEdgeView);
         configureViewerOptions(context, {
             needsClientLayout: false

--- a/client/examples/circlegraph/src/model.ts
+++ b/client/examples/circlegraph/src/model.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (C) 2018 EclipseSource and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { RotatedRectangularNode } from "../../../src";
+
+export class RhombusNode extends RotatedRectangularNode {
+    rotationInDegrees = 45;
+}

--- a/client/examples/circlegraph/src/standalone.ts
+++ b/client/examples/circlegraph/src/standalone.ts
@@ -19,10 +19,10 @@ export default function runStandalone() {
     const graph: SGraphSchema = { id: 'graph', type: 'graph', children: [node0] };
 
     let count = 2;
-    function addNode(): SModelElementSchema[] {
+    function createConnectedNode(nodeType: string): SModelElementSchema[] {
         const newNode: SNodeSchema = {
             id: 'node' + count,
-            type: 'node:circle',
+            type: nodeType,
             position: {
                 x: Math.random() * 1024,
                 y: Math.random() * 768
@@ -42,7 +42,7 @@ export default function runStandalone() {
     }
 
     for (let i = 0; i < 200; ++i) {
-        const newElements = addNode();
+        const newElements = createConnectedNode('node:circle');
         for (const e of newElements) {
             graph.children.splice(0, 0, e);
         }
@@ -52,13 +52,21 @@ export default function runStandalone() {
     const modelSource = container.get<LocalModelSource>(TYPES.ModelSource);
     modelSource.setModel(graph);
 
-    // Button features
-    document.getElementById('addNode')!.addEventListener('click', () => {
-        const newElements = addNode();
-        modelSource.addElements(newElements);
+
+    function addElements(elements: SModelElementSchema[]) {
+        modelSource.addElements(elements);
         const graphElement = document.getElementById('graph');
         if (graphElement !== null && typeof graphElement.focus === 'function')
             graphElement.focus();
+    }
+
+    // Button features
+    document.getElementById('addCircularNode')!.addEventListener('click', () => {
+        addElements(createConnectedNode('node:circle'));
+    });
+
+    document.getElementById('addRectangularNode')!.addEventListener('click', () => {
+        addElements(createConnectedNode('node:rectangle'));
     });
 
     const dispatcher = container.get<IActionDispatcher>(TYPES.IActionDispatcher);

--- a/client/src/features/rotation/model.ts
+++ b/client/src/features/rotation/model.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 EclipseSource and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import { SModelElement } from "../../base/model/smodel";
+import { SModelExtension } from "../../base/model/smodel-extension";
+
+export const rotationFeature = Symbol('rotationFeature');
+
+/**
+ * An element that can be rotated.
+ */
+export interface Rotatable extends SModelExtension {
+    rotationInDegrees: number
+}
+
+export function isRotated(element: SModelElement): element is SModelElement  {
+    return element.hasFeature(rotationFeature) && (element as any)['rotationInDegrees'] !== undefined;
+}

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -95,6 +95,8 @@ export * from "./features/viewport/viewport-root";
 export * from "./features/viewport/viewport";
 export * from "./features/viewport/zoom";
 
+export * from "./features/rotation/model";
+
 import moveModule from "./features/move/di.config";
 import boundsModule from "./features/bounds/di.config";
 import fadeModule from "./features/fade/di.config";

--- a/client/src/lib/model.ts
+++ b/client/src/lib/model.ts
@@ -5,13 +5,15 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { SModelRoot, SModelRootSchema, SChildElement, SModelElementSchema } from "../base/model/smodel";
-import { Point, Dimension, ORIGIN_POINT, EMPTY_DIMENSION, Bounds } from "../utils/geometry";
-import { computeCircleAnchor, computeRectangleAnchor } from '../utils/anchors';
-import { BoundsAware, boundsFeature, Alignable, alignFeature } from "../features/bounds/model";
+import { SChildElement, SModelElementSchema, SModelRoot, SModelRootSchema, SParentElement } from "../base/model/smodel";
+import { Alignable, alignFeature, BoundsAware, boundsFeature } from "../features/bounds/model";
 import { Locateable, moveFeature } from "../features/move/model";
 import { Selectable, selectFeature } from "../features/select/model";
-import { SNode, SPort } from '../graph/sgraph';
+import { SEdge, SNode, SPort } from '../graph/sgraph';
+import { computeCircleAnchor, computeRectangleAnchor } from '../utils/anchors';
+import { center, rotatePoint } from '../utils/geometry';
+import { Bounds, Dimension, EMPTY_DIMENSION, ORIGIN_POINT, Point } from "../utils/geometry";
+import { Rotatable } from "../features/rotation/model";
 
 /**
  * A node that is represented by a circle.
@@ -39,6 +41,21 @@ export class RectangularNode extends SNode {
     getAnchor(refPoint: Point, offset: number = 0): Point {
         const strokeCorrection = 0.5 * this.strokeWidth;
         return computeRectangleAnchor(this.bounds, refPoint, offset + strokeCorrection);
+    }
+}
+
+/**
+ * A node that is represented by a rotated rectangle.
+ */
+export class RotatedRectangularNode extends RectangularNode implements Rotatable {
+
+    rotationInDegrees: number = 0;
+
+    getTranslatedAnchor(refPoint: Point, refContainer: SParentElement, edge: SEdge, offset?: number): Point {
+        const centerPoint = center(this.bounds);
+        const translatedRefPoint = rotatePoint(centerPoint, -this.rotationInDegrees, refPoint);
+        const originalAnchor = super.getTranslatedAnchor(translatedRefPoint, refContainer, edge, offset);
+        return rotatePoint(centerPoint, this.rotationInDegrees, originalAnchor);
     }
 }
 

--- a/client/src/lib/svg-views.tsx
+++ b/client/src/lib/svg-views.tsx
@@ -15,6 +15,7 @@ import { ViewportRootElement } from "../features/viewport/viewport-root";
 import { SShapeElement } from '../features/bounds/model';
 import { Hoverable } from '../features/hover/model';
 import { Selectable } from '../features/select/model';
+import { Rotatable } from '../features/rotation/model';
 
 export class SvgViewportView implements IView {
     render(model: Readonly<ViewportRootElement>, context: RenderingContext): VNode {
@@ -50,6 +51,20 @@ export class RectangularNodeView implements IView {
             <rect class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
                   class-mouseover={node.hoverFeedback} class-selected={node.selected}
                   x="0" y="0" width={Math.max(node.size.width, 0)} height={Math.max(node.size.height, 0)}></rect>
+            {context.renderChildren(node)}
+        </g>;
+    }
+}
+
+export class RotatedRectangularNodeView extends RectangularNodeView {
+    render(node: Readonly<SShapeElement & Hoverable & Selectable & Rotatable>, context: RenderingContext): VNode {
+        const hw = node.bounds.width / 2;
+        const hh = node.bounds.height / 2;
+        return <g>
+            <rect class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
+                  class-mouseover={node.hoverFeedback} class-selected={node.selected}
+                  x="0" y="0" width={Math.max(node.size.width, 0)} height={Math.max(node.size.height, 0)}
+                  transform={`rotate(${node.rotationInDegrees},${hw},${hh})`}></rect>
             {context.renderChildren(node)}
         </g>;
     }

--- a/client/src/utils/geometry.ts
+++ b/client/src/utils/geometry.ts
@@ -251,3 +251,24 @@ export function toRadians(a: number): number {
 export function almostEquals(a: number, b: number): boolean {
     return Math.abs(a - b) < 1e-3;
 }
+
+/**
+ * Rotates a `point` around a `centerPoint` for the specified `angle`
+ * @param {Point} centerPoint Center around to rotate
+ * @param {number} angle - Angle in degree
+ * @param {Point} point - Point to rotate around `centerPoint`
+ */
+export function rotatePoint(centerPoint: Point, angle: number, point: Point): Point {
+    const x = point.x - centerPoint.x;
+    const y = point.y - centerPoint.y;
+    const rad = toRadians(angle);
+    const s = Math.sin(rad);
+    const c = Math.cos(rad);
+    const xnew = x * c - y * s;
+    const ynew = x * s + y * c;
+
+    return {
+        x: xnew + centerPoint.x,
+        y: ynew + centerPoint.y
+    };
+}


### PR DESCRIPTION
This change improves the anchoring of edges on rotated rectangles #235. The purpose of the second commit ab10dd5 is just to demonstrate the usage of rotated rectangles by adding it to the circle example. If you prefer not to include the extension of the circle example, I'm happy to open another PR that includes commit c199af8.

Please let me know what you think! Thanks a lot in advance!