### PR TITLE
Add diamond nodes

### DIFF
--- a/client/src/lib/model.ts
+++ b/client/src/lib/model.ts
@@ -7,7 +7,7 @@
 
 import { SModelRoot, SModelRootSchema, SChildElement, SModelElementSchema } from "../base/model/smodel";
 import { Point, Dimension, ORIGIN_POINT, EMPTY_DIMENSION, Bounds } from "../utils/geometry";
-import { computeCircleAnchor, computeRectangleAnchor } from '../utils/anchors';
+import { computeCircleAnchor, computeRectangleAnchor, computeDiamondAnchor } from '../utils/anchors';
 import { BoundsAware, boundsFeature, Alignable, alignFeature } from "../features/bounds/model";
 import { Locateable, moveFeature } from "../features/move/model";
 import { Selectable, selectFeature } from "../features/select/model";
@@ -39,6 +39,18 @@ export class RectangularNode extends SNode {
     getAnchor(refPoint: Point, offset: number = 0): Point {
         const strokeCorrection = 0.5 * this.strokeWidth;
         return computeRectangleAnchor(this.bounds, refPoint, offset + strokeCorrection);
+    }
+}
+
+/**
+ * A node that is represented by a diamond.
+ */
+export class DiamondNode extends SNode {
+    strokeWidth: number = 0;
+
+    getAnchor(refPoint: Point, offset: number = 0): Point {
+        const strokeCorrection = 0.5 * this.strokeWidth;
+        return computeDiamondAnchor(this.bounds, refPoint, offset + strokeCorrection);
     }
 }
 

--- a/client/src/lib/svg-views.tsx
+++ b/client/src/lib/svg-views.tsx
@@ -15,6 +15,7 @@ import { ViewportRootElement } from "../features/viewport/viewport-root";
 import { SShapeElement } from '../features/bounds/model';
 import { Hoverable } from '../features/hover/model';
 import { Selectable } from '../features/select/model';
+import { Diamond, Point } from '../utils/geometry';
 
 export class SvgViewportView implements IView {
     render(model: Readonly<ViewportRootElement>, context: RenderingContext): VNode {
@@ -53,4 +54,21 @@ export class RectangularNodeView implements IView {
             {context.renderChildren(node)}
         </g>;
     }
+}
+
+export class DiamondNodeView implements IView {
+    render(node: Readonly<SShapeElement & Hoverable & Selectable>, context: RenderingContext): VNode {
+        const diamond = new Diamond({ height: Math.max(node.size.height, 0), width: Math.max(node.size.width, 0), x: 0, y: 0 });
+        const points = `${svgStr(diamond.topPoint)} ${svgStr(diamond.rightPoint)} ${svgStr(diamond.bottomPoint)} ${svgStr(diamond.leftPoint)}`;
+        return <g>
+            <polygon class-sprotty-node={node instanceof SNode} class-sprotty-port={node instanceof SPort}
+                  class-mouseover={node.hoverFeedback} class-selected={node.selected}
+                  points={points} />
+            {context.renderChildren(node)}
+        </g>;
+    }
+}
+
+function svgStr(point: Point) {
+    return `${point.x},${point.y}`;
 }

--- a/client/src/utils/anchors.ts
+++ b/client/src/utils/anchors.ts
@@ -5,7 +5,7 @@
  * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import { Point, Bounds, center, almostEquals } from './geometry';
+import { Point, Bounds, center, almostEquals, PointToPointLine, Diamond, shiftTowards } from './geometry';
 
 export function computeCircleAnchor(position: Point, radius: number, refPoint: Point, offset: number = 0): Point {
     const cx = position.x + radius;
@@ -79,4 +79,11 @@ export function computeRectangleAnchor(bounds: Bounds, refPoint: Point, offset: 
             finder.addCandidate(bounds.x + bounds.width + offset, yRight);
     }
     return finder.best;
+}
+
+export function computeDiamondAnchor(bounds: Bounds, refPoint: Point, offset: number): Point {
+    const referenceLine = new PointToPointLine(center(bounds), refPoint);
+    const closestDiamondSide = new Diamond(bounds).closestSideLine(refPoint);
+    const anchorPoint = closestDiamondSide.intersection(referenceLine);
+    return shiftTowards(anchorPoint, refPoint, offset);
 }

--- a/client/src/utils/geometry.ts
+++ b/client/src/utils/geometry.ts
@@ -227,19 +227,39 @@ export function angleBetweenPoints(a: Point, b: Point): number {
 /**
  * Computes a point that is the original `point` shifted towards `refPoint` by the given `distance`.
  * @param {Point} point - Point to shift
- * @param refPoint - Point to shift towards
- * @param distance - Distance to shift
+ * @param {Point} refPoint - Point to shift towards
+ * @param {Point} distance - Distance to shift
  */
-export function shiftTowards(point: Point, refPoint: Point, distance: number) {
-    const xDistance = refPoint.x - point.x;
-    const yDistance = refPoint.y - point.y;
-    const angle = Math.atan2(yDistance, xDistance);
-    const xShift = distance * Math.cos(angle);
-    const yShift = distance * Math.sin(angle);
+export function shiftTowards(point: Point, refPoint: Point, distance: number): Point {
+    const diff = subtract(refPoint, point);
+    const normalized = normalize(diff);
+    const shift = {x: normalized.x * distance, y: normalized.y * distance};
+    return add(point, shift);
+}
+
+/**
+ * Computes the normalized vector from the vector given in `point`; that is, computing its unit vector.
+ * @param {Point} point - Point representing the vector to be normalized
+ * @returns {Point} The normalized point
+ */
+export function normalize(point: Point): Point {
+    const mag = magnitude(point);
+    if (mag === 0 || mag === 1) {
+        return ORIGIN_POINT;
+    }
     return {
-        x: point.x + xShift,
-        y: point.y + yShift
+        x: point.x / mag,
+        y: point.y / mag
     };
+}
+
+/**
+ * Computes the magnitude of the vector given in `point`.
+ * @param {Point} point - Point representing the vector to compute the magnitude for
+ * @returns {number} The magnitude or also known as length of the `point`
+ */
+export function magnitude(point: Point): number {
+    return Math.sqrt(Math.pow(point.x, 2) + Math.pow(point.y, 2));
 }
 
 /**
@@ -348,7 +368,7 @@ export class Diamond {
 }
 
 /**
- * A line represented as a Cartesian equation.
+ * A line represented in its standard form `a*x + b*y = c`.
  */
 export interface Line {
 


### PR DESCRIPTION
This change introduces a diamond shaped node with proper anchoring of connections. With that, we address usecase 2 of #235. See in particular https://github.com/theia-ide/sprotty/issues/235#issuecomment-419215072.

If you want to try it out, I integrated the new diamond node into the circles example in branch https://github.com/planger:sprotty/tree/issue235-2-with-example. Anyway, below are two screenshots of a couple of nodes with equal and different width/height.

![image](https://user-images.githubusercontent.com/588090/45445089-976d3b00-b6c9-11e8-815e-6699579c99cc.png)

![image](https://user-images.githubusercontent.com/588090/45445376-545f9780-b6ca-11e8-983b-021208703d09.png)
